### PR TITLE
docs: use neutral wording for pets-vs-cattle metaphor

### DIFF
--- a/lectures/lec1.md
+++ b/lectures/lec1.md
@@ -350,10 +350,10 @@ flowchart TD
   S3 --> Drift
 ```
 
-> 🐶🐄 **"Pets vs Cattle"** — Which do you have?
+> 🧩 **Disposable vs unique infrastructure ("Pets vs Cattle")** — Which do you have?
 
-**🐶 Pets:** Unique, irreplaceable, nursed back to health
-**🐄 Cattle:** Identical, replaceable, automated
+**🐶 Unique servers ("pets")**: Irreplaceable, manually nursed back to health
+**🔁 Disposable servers ("cattle")**: Identical, replaceable, automated
 
 ---
 
@@ -374,7 +374,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-**🎯 Result:** Cattle, not pets. Replace, don't repair.
+**🎯 Result:** Disposable, not unique. Replace, don't repair.
 
 **🛠️ IaC Tools:**
 * 🌍 **Terraform** — Multi-cloud


### PR DESCRIPTION
## Summary
- update the Lecture 1 metaphor section from only "pets vs cattle" wording to clearer neutral terminology
- keep the familiar phrase in parentheses for recognition
- align the result statement with replaceable/disposable infrastructure language

## Why
This preserves the DevOps concept while using language that is clearer and less animal-objectifying.

No technical or functional changes.
